### PR TITLE
Add new traits to to support better MLJ machine type checks and composite models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatisticalTraits"
 uuid = "64bff920-2084-43da-a3e6-9bb72801c0c9"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "2.0.1"
+version = "2.1.0"
 
 [deps]
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"

--- a/src/StatisticalTraits.jl
+++ b/src/StatisticalTraits.jl
@@ -9,6 +9,10 @@ const TRAITS = [
     :input_scitype,
     :output_scitype,
     :target_scitype,
+    :training_scitype, #
+    :predict_scitype,  #
+    :transform_scitype, #
+    :inverse_transform_scitype, #
     :is_pure_julia,
     :package_name,
     :package_license,
@@ -24,6 +28,7 @@ const TRAITS = [
     :human_name,
     :is_supervised,
     :prediction_type,
+    :abstract_type, #
     :hyperparameters,
     :hyperparameter_types,
     :hyperparameter_ranges,
@@ -133,6 +138,10 @@ snakecase(s::Symbol) = Symbol(snakecase(string(s)))
 input_scitype(::Type)          = Unknown
 output_scitype(::Type)         = Unknown
 target_scitype(::Type)         = Unknown
+training_scitype(::Type)       = Unknown
+predict_scitype(::Type)        = Unknown
+transform_scitype(::Type)      = Unknown
+inverse_transform_scitype(::Type)  = Unknown
 
 # The following refer to properties of the package defining a type,
 # for use in, say, a registry of machine learning models. All but the
@@ -157,6 +166,7 @@ prediction_type(::Type)        = :unknown
 
 # Miscellaneous:
 
+abstract_type(::Type)   = Any
 is_wrapper(::Type)      = false     # or `true`
 supports_online(::Type) = false     # or `true`
 docstring(M::Type)      = string(M) # some `String`

--- a/src/StatisticalTraits.jl
+++ b/src/StatisticalTraits.jl
@@ -9,7 +9,7 @@ const TRAITS = [
     :input_scitype,
     :output_scitype,
     :target_scitype,
-    :training_scitype, #
+    :fit_data_scitype, #
     :predict_scitype,  #
     :transform_scitype, #
     :inverse_transform_scitype, #
@@ -138,7 +138,7 @@ snakecase(s::Symbol) = Symbol(snakecase(string(s)))
 input_scitype(::Type)          = Unknown
 output_scitype(::Type)         = Unknown
 target_scitype(::Type)         = Unknown
-training_scitype(::Type)       = Unknown
+fit_data_scitype(::Type)       = Unknown
 predict_scitype(::Type)        = Unknown
 transform_scitype(::Type)      = Unknown
 inverse_transform_scitype(::Type)  = Unknown


### PR DESCRIPTION
Add the following traits with specified fallbacks:

*<>* `fit_data_scitype = Unknown` - for the scitype of `data` in `fit(model, verbosity, data...)` calls (and whence `machine(model, data...)` calls). For example, a supervised classification model, the value might be something like like `Tuple{Table(Continuous),AbstractVector{Finite}}`. If the model additionally supported weights, the value might be 

```julia
Union{Tuple{Table(Continuous),AbstractVector{Finite}},
      Tuple{Table(Continuous),AbstractVector{Finite},AbstractVector{Continuous}}
```

 For current abstract `Model` subtypes, this trait would have a fallback inferred from existing traits, but this allows for models to have one or more custom fit signatures, and allows for a better fallback check for data bound to machines.

*<>* `predict_scitype = Unknown` - a guaranteed upper bound for the scitype of the output of `predict` method, as distinguished from `target_scitype` which is the scitype of the training "target". For supervised models these only agree in the `Deterministic` case, not the `Probablistic` case, which generally involves `Density` or `Sampleable` scitypes. For example, a probabilistic classifier might get the value `AbstractVector{Density{<:Finite}}`. For existing `Model` subtypes, this is to be inferred as far as possible from the `target_scitype` and `prediction_type` traits.

*<>* `transform_scitype = Unknown`, `inverse_transform_scitype=Unknown` - similar to above `predict_scitype`.

*<>* `abstract_type = Any` - this will generally be the direct supertype of the model. So, for example, a probabilistic classifier will get the value `Probabilistic`. 

