### PR TITLE
make `info` method a stub and modify it's docstring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "StatisticalTraits"
+\name = "StatisticalTraits"
 uuid = "64bff920-2084-43da-a3e6-9bb72801c0c9"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 version = "2.1.0"
@@ -7,7 +7,7 @@ version = "2.1.0"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
 
 [compat]
-ScientificTypesBase = "^1, 2"
+ScientificTypesBase = "^1, 2, 3"
 julia = "^1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-\name = "StatisticalTraits"
+name = "StatisticalTraits"
 uuid = "64bff920-2084-43da-a3e6-9bb72801c0c9"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 version = "2.1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "2.1.0"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
 
 [compat]
-ScientificTypesBase = "^1, 2, 3"
+ScientificTypesBase = "1, 2, 3"
 julia = "^1"
 
 [extras]

--- a/src/StatisticalTraits.jl
+++ b/src/StatisticalTraits.jl
@@ -211,17 +211,12 @@ end
 """
     info(X)
 
-Return a named-tuple of trait values for `X`, keyed on a list of
+Return a named-tuple of trait values for `X`, keyed on the names of
 traits that are meaninful for the object.
 
 *Note on overloading.* This method can be overloaded directly, as in
-`info(X::SomeAbstractType) = ...` or, using `info(X,
-::Val{:some_trait}) = ...` where `:some_trait` is a key of
-`ScientificTypesBase.TRAIT_FUNCTION_GIVEN_NAME` (such as `:is_measure`
-with value `is_measure`).
-
+`info(X::SomeAbstractType) = ...`.
 """
-info(X) = info(X, Val(ScientificTypesBase.trait(X)))
-info(X, ::Val{:other}) = NamedTuple()
+function info end
 
-end # module
+end #module

--- a/src/StatisticalTraits.jl
+++ b/src/StatisticalTraits.jl
@@ -212,7 +212,7 @@ end
     info(X)
 
 Return a named-tuple of trait values for `X`, keyed on the names of
-traits that are meaninful for the object.
+traits that are meaningful for the object.
 
 *Note on overloading.* This method can be overloaded directly, as in
 `info(X::SomeAbstractType) = ...`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,8 +99,3 @@ const NONCONSTANT = [:docstring,
         Main.eval(ex)
     end
 end
-
-
-## INFO STUB
-
-@test StatisticalTraits.info(42) == NamedTuple()


### PR DESCRIPTION
In line with the removal of `TRAIT_FUNCTION_GIVEN_NAME`, `trait` function and `SET_CONVENTION`  from `ScientificTypesBase.jl` [here](https://github.com/JuliaAI/ScientificTypesBase.jl/pull/24), there is a need to modify the behavior  of the `info` method which previously relies on `trait` function and `TRAIT_FUNCTION_DICTIONARY`.

The `info` stub can be overloaded as needed. For example to define `info` method for all `Measure` instances one can define
```julia
info(m::Measure) = ...
```
cc. @ablaom 