### PR TITLE
add `reports_feature_importances` trait.

### DIFF
--- a/src/StatisticalTraits.jl
+++ b/src/StatisticalTraits.jl
@@ -34,6 +34,7 @@ const TRAITS = [
     :hyperparameter_ranges,
     :orientation,
     :reports_each_observation,
+    :reports_intrinsic_importances,
     :aggregation,
     :is_feature_dependent,
     :distribution_type,
@@ -176,6 +177,7 @@ orientation(::Type)     = :loss  # or `:score`, `:other`
 aggregation(::Type)     = Mean()
 is_feature_dependent(::Type)     = false
 reports_each_observation(::Type) = false
+reports_intrinsic_importances(::Type) = false
 distribution_type(::Type)        = missing
 iteration_parameter(::Type)      = nothing
 supports_training_losses(::Type) = false

--- a/src/StatisticalTraits.jl
+++ b/src/StatisticalTraits.jl
@@ -34,7 +34,7 @@ const TRAITS = [
     :hyperparameter_ranges,
     :orientation,
     :reports_each_observation,
-    :reports_intrinsic_importances,
+    :reports_feature_importances,
     :aggregation,
     :is_feature_dependent,
     :distribution_type,
@@ -177,7 +177,7 @@ orientation(::Type)     = :loss  # or `:score`, `:other`
 aggregation(::Type)     = Mean()
 is_feature_dependent(::Type)     = false
 reports_each_observation(::Type) = false
-reports_intrinsic_importances(::Type) = false
+reports_feature_importances(::Type) = false
 distribution_type(::Type)        = missing
 iteration_parameter(::Type)      = nothing
 supports_training_losses(::Type) = false


### PR DESCRIPTION
This PR adds a new trait `reports_feature_importances` which is overloaded for models reporting intrinsic feature importances e.g `RandomForestClassifier`. 

cc. @ablaom 