### PR TITLE
Add `reporting_operations` trait

### DIFF
--- a/src/StatisticalTraits.jl
+++ b/src/StatisticalTraits.jl
@@ -40,7 +40,8 @@ const TRAITS = [
     :distribution_type,
     :iteration_parameter,
     :supports_training_losses,
-    :deep_properties
+    :deep_properties,
+    :reporting_operations,
 ]
 
 
@@ -182,6 +183,7 @@ distribution_type(::Type)        = missing
 iteration_parameter(::Type)      = nothing
 supports_training_losses(::Type) = false
 deep_properties(::Type) = ()
+reporting_operations(::Type) = ()
 
 # Returns a tuple, with one entry per field of `T` (the type of some
 # statistical model, for example). Each entry is `nothing` or defines


### PR DESCRIPTION
To list operations (`:transform`, `:predict`, etc) of a model that return an extra "report" component.

To support proposal at MLJBase to be cross-referenced below.