### PR TITLE
Add the `tags` trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         version:
           - '1.6'
+          - '1.10'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: julia-actions/cache@v1
         env:
           cache-name: cache-artifacts
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
 [compat]
 REPL = "1.11.0"
 ScientificTypesBase = "1, 2, 3"
-julia = "^1"
+julia = "1.6"
 
 [extras]
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "3.4.0"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
 
 [compat]
-REPL = "1.11.0"
 ScientificTypesBase = "1, 2, 3"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,14 @@ version = "3.4.0"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
 
 [compat]
+REPL = "1.11.0"
 ScientificTypesBase = "1, 2, 3"
 julia = "^1"
 
 [extras]
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SparseArrays"]
+test = ["Test", "REPL", "SparseArrays"]

--- a/src/StatisticalTraits.jl
+++ b/src/StatisticalTraits.jl
@@ -27,6 +27,7 @@ const TRAITS = [
     :docstring,
     :name,
     :human_name,
+    :tags,
     :is_supervised,
     :prediction_type,
     :abstract_type, #
@@ -178,6 +179,7 @@ docstring(M::Type)      = string(M) # some `String`
 docstring(Constructor::Function) = Base.Docs.doc(Constructor) |> string
 is_supervised(::Type)   = false     # or `true`
 human_name(M::Type)     = snakecase(name(M), delim=' ') # `name` defined below
+tags(::Type)            = String[]
 orientation(::Type)     = :loss  # or `:score`, `:other`
 aggregation(::Type)     = Mean()
 is_feature_dependent(::Type)     = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using StatisticalTraits
 using ScientificTypesBase
 import SparseArrays
+using REPL
 
 module Fruit
 


### PR DESCRIPTION
Intended to have values like `["regression", "gradient descent"]`.

Looking to have models declare appropriate values, to avoid us needing to maintain [this tags database](https://github.com/JuliaAI/MLJ.jl/blob/dev/docs/ModelDescriptors.toml) as new models are added to the MLJ Model Registry.